### PR TITLE
rounding: create fix-ready issues in audited repositories

### DIFF
--- a/rounding/README.md
+++ b/rounding/README.md
@@ -6,10 +6,12 @@ with trailing zeros.
 
 ## What it does
 
-Given a pinned R source tree and an approved display-precision specification,
+Given a pinned repository and an approved display-precision specification,
 the skill inventories every operation that can change a displayed number or a
-number that decides which rows appear, proves what each one does with executed
-witnesses, and drafts a report for a named rule owner to classify.
+number that decides which rows appear. It scans installed R code plus executable
+reporting logic in scripts, READMEs, and vignettes (`.R`, `.Rmd`, `.qmd`,
+`.Rnw`), proves behavior with executed witnesses, and drafts a report for a
+named rule owner to classify.
 
 BR-001: Values intended as exact decimal ties are rounded half away from zero. A displayed value is never a negative zero.
 

--- a/rounding/README.md
+++ b/rounding/README.md
@@ -19,8 +19,9 @@ BR-002: Calculations use unrounded values; rounding occurs once, when the final 
 
 BR-003: Display precision is specified for each reported statistic and preserved, including trailing zeros.
 
-It is an advisory drafting aid, not a QC replacement. It changes no source,
-approves no classification, and posts nothing.
+It is an advisory drafting aid, not a QC replacement. It changes no source or
+policy. When the user explicitly authorizes a fix-ready finding, it may create
+one deduplicated issue in the audited repository after evidence is verified.
 
 ## Usage
 
@@ -45,13 +46,17 @@ first and audit the working tree read-only.
 
 - `report.md` (inventory table + Coverage, Findings, Clean checks, Limitations,
   decisions required, with embedded executed witnesses)
+- With explicit authorization: one verified, fix-ready issue in the audited
+  repository (never in this skill repository unless it is the audit target)
 
 ## Requirements
 
 - R (>= 4.0) with `Rscript`. The scripts are base-R only; a half-away package
   (`cards`, `tidytlg`, `janitor`) is cross-checked when installed but is not
   required to produce witnesses.
-- No source edits, policy changes, or external posting.
+- No source edits or policy changes. External issues require explicit user
+  authorization, an evidence-backed FAIL, duplicate search, and read-back
+  verification.
 
 ## Benchmark
 

--- a/rounding/SKILL.md
+++ b/rounding/SKILL.md
@@ -13,7 +13,7 @@ description: >
 license: MIT
 metadata:
   author: Pharma Skills community
-  version: "0.5"
+  version: "0.6"
   rules-version: "BR-001/002/003 v1.0"
 ---
 
@@ -44,32 +44,15 @@ Use this skill when the user asks to:
 
 See also *When NOT to use this skill* at the end.
 
-## Examples
+## Scope example
 
-**Example 1 -- trailing zeros look wrong:**
-
-Input: "Our mock AE tables show `76` where the spec says two decimals, and one
-percent column shows `2%` instead of `2.0%`. Spec is in `precision-spec.yml`.
-Source is `myanalysis/R/`. Save what you find to `report.md`."
-
-Output: `report.md` with Coverage, Findings for `R/render.R:13` (`as.character`
-→ `76` vs `76.00`) and `R/rounding-helpers.R:19` (`paste0` → `2%` vs `2.0%`),
-each with an executed string witness and a fixed-character fix
-(`formatC(..., format="f")` / `sprintf` / `as_char=TRUE`). Tie/Stage rules are
-named as checked or explicitly `NOT ASSESSABLE`, not silently dropped.
-
-**Example 2 -- SAS tie-method audit:**
-
-Input: "Audit `myanalysis/R/**/*.R` against SAS-compatible ties-away-from-zero
-(`2.5 -> 3`). Entry points are `report_*()`, spec is `precision-spec.yml`,
-output to `report.md`."
-
-Output: `report.md` with 14 inventory rows (one per operation-and-entry-path),
-each with Tie/Stage/Display verdicts, before/after executed witnesses (e.g.
-`base::round(2.5)=2` vs policy `3`), paired-stage tracing for
-`R/report-change.R:6` + `R/render.R:5`, explicit two-cause attribution for
-`formatC`/`round` divergence, and embedded `probe-tie-behavior.R` stdout
-including `R.version.string`.
+A repository audit is not limited to installed package code. Treat executable
+reporting examples in `Rmd`/`qmd` as report entry paths too: a vignette that
+computes a mean, percentage, CI, or p-value and sends it to `rtf_*()`,
+`write_rtf()`, a table, or a listing is in scope even when no exported
+`report_*()` function calls it. Tests and pure rendering/layout examples stay
+visible in Coverage and are excluded unless they themselves generate report
+statistics.
 
 ## Bundled resources
 
@@ -96,8 +79,9 @@ Collect these before scanning. A rule the request is silent on is
   reported statistic. A statistic with no entry is `NOT ASSESSABLE`.
 - **Tie policy and its version**, plus the comparison helper the rule owner
   selected and that package's version.
-- **Entry points**: which exported functions produce reported output (often
-  `report_*()`). Reachability from an entry point is what makes a site in scope.
+- **Entry paths**: exported report functions, scripts, and executable chunks in
+  `.Rmd`/`.qmd`/`.Rnw` that calculate or prepare reported statistics. A caller
+  need not be exported: observable reporting behavior makes it in scope.
 - **Rule owner**: the named person who will classify each finding. Record the
   name in the report. An unnamed gate is not a gate.
 - **Allowlist** (optional): sites the rule owner has already classified. See
@@ -109,15 +93,20 @@ Collect these before scanning. A rule the request is silent on is
    the source to settle whatever it can settle. Ask about a gap you cannot
    close, but do not let one unanswered question stop the parts of the review
    it does not touch -- see *Missing inputs* below.
-2. **Scan (first pass only).** Read `references/function-catalog.md`, run
-   `scripts/scan-rounding-calls.R`, preserve the full output. Then infer where
-   else rounding can hide: the script never clears a file. Label each candidate
-   `catalog`, `wrapper`, `operator`, or `exploratory` and keep those labels to
-   the end, so a reader can tell reproducible output from your reasoning.
-3. **Trace and triage.** From each entry point follow package-local calls.
-   Keep reachable operations as rows; move the rest to Coverage as excluded
-   with reasons. Trace paired sites (early rounding + downstream display or
-   decision) together.
+2. **Scan the whole repository (first pass only).** Read
+   `references/function-catalog.md`, then run `scripts/scan-rounding-calls.R`
+   at the repository root—not just `R/`. Confirm Coverage accounts separately
+   for every discovered `.R`, `.r`, `.Rmd`, `.rmd`, `.qmd`, and `.Rnw` file;
+   use `--include-tests` when tests contain reporting fixtures or executable
+   examples. Preserve the full output. The scanner never clears a file, so
+   inspect zero-hit literate files and infer where dynamic rounding can hide.
+   Label candidates `catalog`, `wrapper`, `operator`, or `exploratory`.
+3. **Trace and triage.** Follow each reporting path, including standalone
+   vignette/helper chunks that compute statistics before table or file output.
+   Export status is irrelevant. Keep each reachable reporting operation as a
+   row; move layout, encoding, solver, plotting, and ordinary test-only hits to
+   Coverage with reasons. Trace paired sites (early rounding + downstream
+   display or decision) together.
 4. **Resolve against the rules.** For each row state namespace, method/class,
    and version, then read the matching `references/br-00x-*.md` for the FAIL
    signature and fix.

--- a/rounding/SKILL.md
+++ b/rounding/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: rounding
 description: >
-  Audit R code that prepares clinical-report statistics for SAS-compatible
-  rounding compliance (ties away from zero, round-once-at-display,
-  fixed display precision with trailing zeros). Use this skill whenever the
-  user asks to review, check, verify, or fix rounding in R code,
-  mentions SAS rounding, half-away-from-zero,
-  display precision, trailing zeros, early rounding, or names round(),
+  Audit R code that prepares CSR/TLF statistics for SAS-compatible rounding
+  compliance (ties away from zero, round-once-at-display, fixed trailing-zero
+  precision). Make sure to use this skill whenever the user asks to review,
+  check, verify, or fix rounding, mentions SAS rounding, half-away-from-zero,
+  display precision, trailing zeros, early rounding, mock tables showing 76
+  not 76.00, percentages off by 1 at the half point, or names round(),
   formatC(), sprintf(), format(), signif(), prettyNum(), cards::round5,
-  tidytlg::roundSAS, or janitor::round_half_up in a CSR/TLF/report context --
-  even if they don't say the word "rounding".
+  tidytlg::roundSAS, or janitor::round_half_up in a clinical-report context --
+  even if they don't say the word rounding.
 license: MIT
 metadata:
   author: Pharma Skills community
@@ -27,6 +27,49 @@ The point of the review is not to find `round()`. It is to establish which
 operations can change a number a reader sees or a number that decides which
 rows they see, and then to prove what each one actually does. Those are
 different questions, and only the second one needs a machine.
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- audit, check, verify, or fix rounding in R reporting code (even if they
+  don't say the word "rounding")
+- compare R and SAS rounding, or mentions ties-away-from-zero / half-away
+- debug trailing-zero or fixed-precision display (e.g. mock tables show
+  `76` where the spec requires `76.00`, or `2%` where it requires `2.0%`)
+- investigate percentages or statistics "off by 1 at the half point"
+- review TLF/CSR/display code that calls `round()`, `formatC()`, `sprintf()`,
+  `format()`, `signif()`, `prettyNum()`, `cards::round5`, `tidytlg::roundSAS`,
+  or `janitor::round_half_up`, or describes early rounding / round-once-at-display
+
+See also *When NOT to use this skill* at the end.
+
+## Examples
+
+**Example 1 -- trailing zeros look wrong:**
+
+Input: "Our mock AE tables show `76` where the spec says two decimals, and one
+percent column shows `2%` instead of `2.0%`. Spec is in `precision-spec.yml`.
+Source is `myanalysis/R/`. Save what you find to `report.md`."
+
+Output: `report.md` with Coverage, Findings for `R/render.R:13` (`as.character`
+→ `76` vs `76.00`) and `R/rounding-helpers.R:19` (`paste0` → `2%` vs `2.0%`),
+each with an executed string witness and a fixed-character fix
+(`formatC(..., format="f")` / `sprintf` / `as_char=TRUE`). Tie/Stage rules are
+named as checked or explicitly `NOT ASSESSABLE`, not silently dropped.
+
+**Example 2 -- SAS tie-method audit:**
+
+Input: "Audit `myanalysis/R/**/*.R` against SAS-compatible ties-away-from-zero
+(`2.5 -> 3`). Entry points are `report_*()`, spec is `precision-spec.yml`,
+output to `report.md`."
+
+Output: `report.md` with 14 inventory rows (one per operation-and-entry-path),
+each with Tie/Stage/Display verdicts, before/after executed witnesses (e.g.
+`base::round(2.5)=2` vs policy `3`), paired-stage tracing for
+`R/report-change.R:6` + `R/render.R:5`, explicit two-cause attribution for
+`formatC`/`round` divergence, and embedded `probe-tie-behavior.R` stdout
+including `R.version.string`.
 
 ## Bundled resources
 
@@ -104,8 +147,28 @@ Collect these before scanning. A rule the request is silent on is
 6. **Verdict and write.** Per row: Tie / Stage / Display as `PASS` / `FAIL` /
    `NOT ASSESSABLE`; Overall is `FAIL` if any rule fails, `NOT ASSESSABLE`
    if none fails and at least one is uncheckable, else `PASS`. Compliant
-   helper-plus-formatter paths pass -- do not rewrite them. Complete
-   `assets/report-template.md` as `report.md`, the only deliverable.
+   helper-plus-formatter paths pass -- do not rewrite them.
+
+   ALWAYS use the exact structure in `assets/report-template.md` (see
+   *Report structure* below). That template is the only deliverable; do not
+   invent sections or rename them.
+
+## Report structure
+
+ALWAYS use this exact template from `assets/report-template.md`:
+
+```markdown
+# Rounding compliance report -- <package> <version/commit>
+Target / Environment / Policy / Status / Verdict (one line each)
+## Summary -- one row per (operation, entry path) with Tie/Stage/Display/Overall
+## Appendix A. Coverage -- files scanned, hits, excluded sites with file:line + reason
+## Appendix B. Evidence (executed) -- policy-vs-actual witnesses per row
+## Appendix C. Limitations -- missing specs, blind spots, uninstalled helpers
+## Appendix D. Witness log -- pasted scripts/probe-tie-behavior.R stdout
+```
+
+Fill every section from executed output; an empty section is a missing section,
+not a clean section.
 
 ## One row per operation *and* entry path
 

--- a/rounding/SKILL.md
+++ b/rounding/SKILL.md
@@ -13,15 +13,15 @@ description: >
 license: MIT
 metadata:
   author: Pharma Skills community
-  version: "0.6"
+  version: "0.7"
   rules-version: "BR-001/002/003 v1.0"
 ---
 
 # Rounding compliance review
 
-Advisory review only. Find candidates, reproduce behavior with executed code,
-and draft findings for a named human to classify. Do not edit source, change
-policy, approve a classification, or post an external issue.
+Default to an advisory report. Do not edit source, change policy, or approve a
+classification. When the user explicitly asks to file a finding, create one
+fix-ready issue in the **audited repository**, not in this skill's repository.
 
 The point of the review is not to find `round()`. It is to establish which
 operations can change a number a reader sees or a number that decides which
@@ -139,8 +139,19 @@ Collect these before scanning. A rule the request is silent on is
    helper-plus-formatter paths pass -- do not rewrite them.
 
    ALWAYS use the exact structure in `assets/report-template.md` (see
-   *Report structure* below). That template is the only deliverable; do not
-   invent sections or rename them.
+   *Report structure* below) for the audit deliverable; do not invent or rename
+   report sections.
+
+7. **File a target-repository issue only when explicitly authorized.** First
+   search the target repository's open issues for the exact paths/rules to
+   avoid duplicates. For each actionable FAIL, create at most one issue in the
+   target repository with: affected `file:line` paths; actual versus required
+   behavior; a minimal executed reproduction; a bounded remediation pattern;
+   acceptance criteria covering positive and negative ties, round-once stage
+   where applicable, fixed-width display, and signed zero; and the pinned
+   target commit. Link the audit report, verify the issue after posting, and
+   report its URL. If the target is read-only, authorization is missing, or the
+   finding is only `NOT ASSESSABLE`, leave a local issue draft instead.
 
 ## Report structure
 
@@ -267,6 +278,14 @@ Stop the whole review only when no trustworthy evidence is obtainable at all:
 
 Record the blocker and stop. Everything else is a `NOT ASSESSABLE` cell in a
 report you still deliver.
+
+## Target-issue mode
+
+Use this mode only for a user-authorized, evidence-backed `FAIL`. The issue is
+a handoff to an implementer, not another audit: give it one defect cluster,
+source anchors, the exact observed/policy values, a non-prescriptive fix
+boundary, and executable acceptance tests. Never open an issue merely to
+repeat scanner candidates, layout/encoding exclusions, or missing policy.
 
 ## When NOT to use this skill
 

--- a/rounding/assets/report-template.md
+++ b/rounding/assets/report-template.md
@@ -60,3 +60,15 @@ Paste `scripts/probe-tie-behavior.R` stdout verbatim (include the default run + 
 ## Decisions Required (for the rule owner)
 
 List each `FAIL` / `NOT ASSESSABLE` row and the classification the owner must make. No approval is recorded here.
+
+## Target issue handoff (only when explicitly authorized)
+
+For one actionable FAIL cluster, prepare a target-repository issue with:
+
+- pinned commit and affected `file:line` paths;
+- actual versus policy behavior and the minimal executed reproduction;
+- a bounded fix pattern, without changing source in this review;
+- acceptance criteria: positive/negative ties, round-once stage where relevant,
+  fixed-width display, and no signed zero;
+- link to this report. Search for a duplicate, post only with authorization,
+  then read the issue back and record its URL.

--- a/rounding/assets/report-template.md
+++ b/rounding/assets/report-template.md
@@ -2,28 +2,60 @@
 
 Target: [<repo link pinned to commit>](<url>) or folder path: <path>
 Environment: <R.version.string; rounding package versions>
-Policy: <tie policy and version>;
+Policy: <tie policy and version; e.g. half away from zero 2.5->3, rule owner: Name>
 Status: **Draft for review.** No source was changed and nothing was posted.
 Verdict: **<PASS / FAIL / NOT ASSESSABLE>** (FAIL if any row fails, NOT ASSESSABLE if none fails and at least one is uncheckable, else PASS).
 
 ## Summary
 
-| Site | What | Tie | Stage | Display | Overall |
-|------|------|-----|-------|---------|---------|
-| R/...:NN | <formatter + digits> | <PASS/FAIL> | <PASS/FAIL> | <PASS/FAIL> | <PASS/FAIL> |
+One row per (operation, entry path). Overall is FAIL if any rule fails.
 
-Fix (advisory): <one-line helper + formatter + neg-zero guard>
+| # | Site | Entry path | Tie | Stage | Display | Overall | Witness (before → after) |
+|---|------|------------|-----|-------|---------|---------|--------------------------|
+| 1 | R/...:NN `func()` | `report_*()` | PASS/FAIL/NOT ASSESSABLE | PASS/FAIL/NOT ASSESSABLE | PASS/FAIL/--/NOT ASSESSABLE | PASS/FAIL/NOT ASSESSABLE | policy `X` vs actual `Y`; fix `Z` |
+| … | … | … | … | … | … | … | … |
 
-## Appendix
+Fix (advisory): <one-line helper + formatter + neg-zero guard, e.g. `tidytlg::roundSAS(x, digits)` + `formatC(..., format="f")`>
 
-### A. Coverage
-- Scanned <N> R files; <K> catalog hits, <N-in> in-scope. Excluded (never scored): <file:line + reason each>.
+## Appendix A. Coverage
 
-### B. Evidence (executed)
-- <policy-vs-actual witnesses, e.g. formatC(2.5)="2" vs "3", "-0" vs never "-0"; stage round-once and trailing-zero checks>
+- Scanned <N> R files (`R/`, `vignettes/`, etc.); <K> catalog hits, <in-scope> in-scope rows, <excluded> excluded.
+- Full scanner output pasted (do not summarize -- paste verbatim).
+- Excluded (never scored), each with file:line + reason:
+  - `R/...:NN` — reason (e.g. inside `solver_*()`, plot coordinates, character input, not reachable from `report_*()`)
+- Note: `R/report-listing.R` reports `hits: 0`; that is a scan result (dynamic `do.call` invisible to parse tree), not a clearance. Label any `exploratory` sites you add by reading the source.
 
-### C. Limitations
-- <missing specs, binary-representation caveats, uninstalled helpers, untraced paths>
+## Appendix B. Evidence (executed)
 
-### D. Witness log
-- <paste scripts/probe-tie-behavior.R stdout, trimmed to key lines>
+For each row, two witnesses:
+
+- **Before** -- observed value vs policy value at the site's own precision.
+- **After** -- recommended fix producing the policy value.
+
+Example row:
+
+- Tie: `base::round(2.5, 0)` → `2` vs policy `3`; `tidytlg::roundSAS(2.5, 0)` → `3` ✓
+- Stage: `x=c(1.25,1.25,1.75)` at 1dp early-rounded `1.5` vs round-once `1.4`
+- Display: `as.character(76.00)` → `"76"` vs spec `exposure_total` requires `"76.00"`; `formatC(76, format="f", digits=2)` → `"76.00"` ✓
+- Neg-zero: `formatC(-0.4, format="f", digits=0)` → `"-0"` must never occur
+
+Attribute `formatC`/`sprintf` divergence to two causes (tie mode + binary representation); do not claim either uses banker's rounding.
+
+## Appendix C. Limitations
+
+- Missing inputs: <which rule/row is NOT ASSESSABLE and what is missing, e.g. `report_ci()` has no entry in `precision-spec.yml`>
+- Blind spots: dynamic dispatch (`do.call`, `get`, `match.fun`), S3/S4 methods, dependency internals
+- Uninstalled helpers: <which versioned helper was recommended but not installed; whether built-in half-away arithmetic was used to demonstrate the pattern>
+- Untraced paths: <any entry path not fully traced>
+
+## Appendix D. Witness log
+
+Paste `scripts/probe-tie-behavior.R` stdout verbatim (include the default run + each `--digits N` run). Must include `R.version.string` and package versions. Unexecuted claims are not evidence.
+
+```
+<paste stdout here>
+```
+
+## Decisions Required (for the rule owner)
+
+List each `FAIL` / `NOT ASSESSABLE` row and the classification the owner must make. No approval is recorded here.

--- a/rounding/assets/report-template.md
+++ b/rounding/assets/report-template.md
@@ -19,7 +19,8 @@ Fix (advisory): <one-line helper + formatter + neg-zero guard, e.g. `tidytlg::ro
 
 ## Appendix A. Coverage
 
-- Scanned <N> R files (`R/`, `vignettes/`, etc.); <K> catalog hits, <in-scope> in-scope rows, <excluded> excluded.
+- Scanned <N> source files from the repository root; report counts by type (`R=<n> Rmd=<n> qmd=<n> Rnw=<n>`), <K> catalog hits, <in-scope> in-scope rows, <excluded> excluded.
+- State which literate reporting files (`Rmd`/`qmd`/`Rnw`) were treated as entry paths; a vignette is not excluded merely because it is not exported.
 - Full scanner output pasted (do not summarize -- paste verbatim).
 - Excluded (never scored), each with file:line + reason:
   - `R/...:NN` — reason (e.g. inside `solver_*()`, plot coordinates, character input, not reachable from `report_*()`)

--- a/rounding/references/function-catalog.md
+++ b/rounding/references/function-catalog.md
@@ -6,6 +6,15 @@ lines is still found. It classifies every hit into one of four labels. Carry
 those labels into the report: they are what lets a reader separate reproducible
 output from your reasoning.
 
+## Reporting paths define scope
+
+Scan from the repository root. Installed `R/` code is only one reporting
+surface: executable chunks in vignettes, READMEs, and other `.Rmd`/`.qmd`/`.Rnw`
+files are in scope when they calculate or prepare statistics for a table,
+listing, figure annotation, or report file. They do not need to be called by an
+export. Exclude layout/encoding math and ordinary tests with reasons, but do not
+exclude reporting examples merely because they live under `vignettes/`.
+
 ## `catalog/quantize` -- rounded numeric out
 
 `round()`, `signif()`, `ceiling()`, `floor()`, `trunc()`, `cards::round5()`,

--- a/rounding/scripts/scan-rounding-calls.R
+++ b/rounding/scripts/scan-rounding-calls.R
@@ -13,7 +13,7 @@
 # them. A file with no hits is listed with `hits: 0`; that is a scan result,
 # not a clearance.
 
-SCANNER_VERSION <- "2.0"
+SCANNER_VERSION <- "2.1"
 
 args <- commandArgs(trailingOnly = TRUE)
 include_tests <- "--include-tests" %in% args
@@ -179,6 +179,14 @@ cat(sprintf("scanner_version: %s\n", SCANNER_VERSION))
 cat(sprintf("root: %s\n", root))
 cat("r_version:", R.version.string, "\n")
 cat(sprintf("files_scanned: %d\n", length(files)))
+ext <- sub("^.*[.]", "", files)
+ext[tolower(ext) == "r"] <- "R"
+ext[tolower(ext) == "rmd"] <- "Rmd"
+ext[tolower(ext) == "qmd"] <- "qmd"
+ext[tolower(ext) == "rnw"] <- "Rnw"
+by_type <- table(ext)
+cat("files_by_type:", paste(sprintf("%s=%d", names(by_type), by_type),
+  collapse = " "), "\n")
 per_file <- table(vapply(hits, function(h) h$file, ""))
 for (f in files) {
   r <- rel(f)


### PR DESCRIPTION
## Summary
- add explicit, user-authorized target-repository issue handoff after an evidence-backed rounding audit FAIL
- require duplicate search, source anchors, executed repro, bounded remediation, acceptance criteria, and read-back verification
- keep source edits and policy changes out of audit scope; bump rounding skill metadata to v0.7

## Validation
- `Rscript rounding/scripts/scan-rounding-calls.R rounding/evals/fixtures/myanalysis` — 12 files, 23 hits
- `Rscript rounding/scripts/probe-tie-behavior.R` — 7/7 invariants held

## Evidence
The workflow was exercised against `Merck/r2rtf`, producing the verified target-repository issue: https://github.com/Merck/r2rtf/issues/296
