### PR TITLE
rounding: keep audit reports concise

### DIFF
--- a/rounding/README.md
+++ b/rounding/README.md
@@ -51,9 +51,7 @@ first and audit the working tree read-only.
 
 ## Requirements
 
-- R (>= 4.0) with `Rscript`. The scripts are base-R only; a half-away package
-  (`cards`, `tidytlg`, `janitor`) is cross-checked when installed but is not
-  required to produce witnesses.
+- R (>= 4.0) with `Rscript`. The scripts are base-R only.
 - No source edits or policy changes. External issues require explicit user
   authorization, an evidence-backed FAIL, duplicate search, and read-back
   verification.

--- a/rounding/SKILL.md
+++ b/rounding/SKILL.md
@@ -13,7 +13,7 @@ description: >
 license: MIT
 metadata:
   author: Pharma Skills community
-  version: "0.7"
+  version: "0.8"
   rules-version: "BR-001/002/003 v1.0"
 ---
 
@@ -63,7 +63,7 @@ statistics.
 | `references/br-002-rounding-stage.md` | Stage rule, FAIL signature, remove-early-rounding fix | Step 4, when BR-002 is in scope |
 | `references/br-003-display-precision.md` | Display rule, FAIL signature, fixed-character fix | Step 4, when BR-003 is in scope |
 | `scripts/scan-rounding-calls.R` | Parse-tree inventory: catalog calls, quantizing operators, wrapper closure | Step 2; its output is never complete coverage |
-| `scripts/probe-tie-behavior.R` | Executed tie/stage/display witnesses; `--digits` for per-site precision | Step 5, embed stdout |
+| `scripts/probe-tie-behavior.R` | Executed tie/stage/display witnesses; `--digits` for per-site precision | Step 5 |
 | `assets/report-template.md` | `report.md` structure | Step 6 |
 
 Do NOT read or run these upfront. Use each only when the step directs.
@@ -110,7 +110,7 @@ Collect these before scanning. A rule the request is silent on is
 4. **Resolve against the rules.** For each row state namespace, method/class,
    and version, then read the matching `references/br-00x-*.md` for the FAIL
    signature and fix.
-5. **Prove.** Run `scripts/probe-tie-behavior.R` and embed its stdout, then
+5. **Prove.** Run `scripts/probe-tie-behavior.R`, then
    re-run it with `--digits N` for each distinct precision the target displays
    -- a witness at the wrong precision does not test the site. Unexecuted
    claims are not evidence.
@@ -128,7 +128,7 @@ Collect these before scanning. A rule the request is silent on is
    observed value against the policy value, and the **after**, showing that the
    fix you recommend actually produces the policy value. A recommendation no one
    has run is a guess, and it is the part of the report a reader is most likely
-   to paste into the codebase. If the selected package helper is not installed,
+   to paste into the codebase. If the selected package helper cannot be run,
    demonstrate the fix *pattern* with the probe's dependency-free half-away
    arithmetic and say that is what you did -- still recommend the versioned
    package, and note that its exact behavior at inexact ties was not confirmed
@@ -163,8 +163,7 @@ Target / Environment / Policy / Status / Verdict (one line each)
 ## Summary -- one row per (operation, entry path) with Tie/Stage/Display/Overall
 ## Appendix A. Coverage -- files scanned, hits, excluded sites with file:line + reason
 ## Appendix B. Evidence (executed) -- policy-vs-actual witnesses per row
-## Appendix C. Limitations -- missing specs, blind spots, uninstalled helpers
-## Appendix D. Witness log -- pasted scripts/probe-tie-behavior.R stdout
+## Appendix C. Limitations -- missing specs and blind spots
 ```
 
 Fill every section from executed output; an empty section is a missing section,

--- a/rounding/assets/report-template.md
+++ b/rounding/assets/report-template.md
@@ -1,7 +1,7 @@
 # Rounding compliance report -- <package> <version/commit>
 
 Target: [<repo link pinned to commit>](<url>) or folder path: <path>
-Environment: <R.version.string; rounding package versions>
+Environment: <R.version.string>
 Policy: <tie policy and version; e.g. half away from zero 2.5->3, rule owner: Name>
 Status: **Draft for review.** No source was changed and nothing was posted.
 Verdict: **<PASS / FAIL / NOT ASSESSABLE>** (FAIL if any row fails, NOT ASSESSABLE if none fails and at least one is uncheckable, else PASS).
@@ -21,7 +21,7 @@ Fix (advisory): <one-line helper + formatter + neg-zero guard, e.g. `tidytlg::ro
 
 - Scanned <N> source files from the repository root; report counts by type (`R=<n> Rmd=<n> qmd=<n> Rnw=<n>`), <K> catalog hits, <in-scope> in-scope rows, <excluded> excluded.
 - State which literate reporting files (`Rmd`/`qmd`/`Rnw`) were treated as entry paths; a vignette is not excluded merely because it is not exported.
-- Full scanner output pasted (do not summarize -- paste verbatim).
+- Record the scanner totals and relevant `file:line` evidence; do not paste full scanner output.
 - Excluded (never scored), each with file:line + reason:
   - `R/...:NN` — reason (e.g. inside `solver_*()`, plot coordinates, character input, not reachable from `report_*()`)
 - Note: `R/report-listing.R` reports `hits: 0`; that is a scan result (dynamic `do.call` invisible to parse tree), not a clearance. Label any `exploratory` sites you add by reading the source.
@@ -46,16 +46,7 @@ Attribute `formatC`/`sprintf` divergence to two causes (tie mode + binary repres
 
 - Missing inputs: <which rule/row is NOT ASSESSABLE and what is missing, e.g. `report_ci()` has no entry in `precision-spec.yml`>
 - Blind spots: dynamic dispatch (`do.call`, `get`, `match.fun`), S3/S4 methods, dependency internals
-- Uninstalled helpers: <which versioned helper was recommended but not installed; whether built-in half-away arithmetic was used to demonstrate the pattern>
 - Untraced paths: <any entry path not fully traced>
-
-## Appendix D. Witness log
-
-Paste `scripts/probe-tie-behavior.R` stdout verbatim (include the default run + each `--digits N` run). Must include `R.version.string` and package versions. Unexecuted claims are not evidence.
-
-```
-<paste stdout here>
-```
 
 ## Decisions Required (for the rule owner)
 


### PR DESCRIPTION
## Summary
- remove Appendix D / pasted probe logs from rounding audit reports
- replace verbatim scanner output with concise totals and relevant source anchors
- remove package-installation status from report output; retain executed before/after evidence
- bump the rounding skill to v0.8

## Validation
- `Rscript rounding/scripts/scan-rounding-calls.R rounding/evals/fixtures/myanalysis` — 12 files, 23 hits
- `Rscript rounding/scripts/probe-tie-behavior.R` — 7/7 invariants held
